### PR TITLE
Fix tests with ?\x error on Emacs master (30.0)

### DIFF
--- a/relint-test.el
+++ b/relint-test.el
@@ -175,15 +175,17 @@ and a path."
             (emacs-lisp-mode)
             (insert "(print \"c \\xf \\xg \\x d\")\n"))
           (let* ((diags (relint-buffer buf))
-                 (err (assoc "(error \"Invalid escape character syntax\")"
-                             diags)))
+                 (err (condition-case err
+                          (read-from-string "?\\x")
+                        (error (prin1-to-string err)))))
             (should (equal
-                     (remove err diags)
-                   '(("Character escape `\\x' not followed by hex digit"
-                      15 nil nil nil warning)
-                     ("Character escape `\\x' not followed by hex digit"
-                      19 nil nil nil warning)
-                     )))))
+                     ;; Ignore 'invalid escape char syntax' error.
+                     (remove (assoc err diags) diags)
+                     '(("Character escape `\\x' not followed by hex digit"
+                        15 nil nil nil warning)
+                       ("Character escape `\\x' not followed by hex digit"
+                        19 nil nil nil warning)
+                       )))))
       (kill-buffer buf))))
 
 (provide 'relint-test)


### PR DESCRIPTION
`make check` with Emacs `HEAD` currently fails:
[check.txt](https://github.com/mattiase/relint/files/11715847/check.txt)

The error message changed from `Invalid escape character syntax`
to `Invalid escape char syntax: \x not followed by hex digit`.

Compute the error message dynamically instead of hard-coding it.