### PR TITLE
Add checks for tree-sitter definitions

### DIFF
--- a/test/1.elisp
+++ b/test/1.elisp
@@ -112,3 +112,6 @@
    ("thing" stuff)
    ("$3$" bad)
    ("^4^" alsobad)))
+
+(defvar my-ts--font-lock-rules '(((a) (:match "[55]" @a))))
+(defvar my-ts-mode-font-lock-rules '(((b) (:match "[66]" @b))))

--- a/test/1.expected
+++ b/test/1.expected
@@ -177,3 +177,9 @@
 1.elisp:114:8: In call to syntax-propertize-precompile-rules: Unescaped literal `^' (pos 2)
   "^4^"
    ..^
+1.elisp:116:34: In my-ts--font-lock-rules: Duplicated `5' inside character alternative (pos 2)
+  "[55]"
+   ..^
+1.elisp:117:38: In my-ts-mode-font-lock-rules: Duplicated `6' inside character alternative (pos 2)
+  "[66]"
+   ..^

--- a/test/14.elisp
+++ b/test/14.elisp
@@ -1,0 +1,42 @@
+;;; Relint test file 14          -*- emacs-lisp -*-
+
+;; Test tree-sitter queries.
+
+(defun test-treesit-font-lock ()
+  (treesit-font-lock-rules
+   :language "+a+"
+   :feature "+b+"
+   '("+c+" ("+d+") (:match "+e+"))
+
+   :language nil
+   :feature nil
+   `(((f @f) (:match "+f+" @f))
+     [((g) @g (:match ,(string ?+ ?g ?+) @g))]
+     ((h @h) (:match "h+" @h)))))
+
+(defun test-treesit-ranges ()
+  (treesit-range-rules
+   :embed "+i+"
+   :host "+j+"
+   '(["+k+"]
+     (("+l+") (:match @l "+m+"))
+     (:match "+n+"))
+
+   #'ignore
+
+   :embed nil
+   :host nil
+   `(((o field: _ @o) (:match "+o+" @o))
+     [((p) @p (:match ,(string ?+ ?p ?+) @p))]
+     ((q field: (_) @q) (:match "q+" @q)))))
+
+(treesit-query-expand '(((r) (:match "+r+" @r))))
+(treesit-query-compile
+ "+s+"
+ '(((s) @s (:match "s+" @s))
+   [[((t) @t (:match "+t+" @t))]]))
+
+(treesit-node-top-level nil '(((u) (:match "+u+" @u))))
+(treesit-query-capture nil '(((v) (:match "+v+" @v))))
+(treesit-query-range nil '(((w) (:match "+w+" @w))))
+(treesit-query-string nil '(((x) (:match "+x+" @x))))

--- a/test/14.expected
+++ b/test/14.expected
@@ -1,0 +1,30 @@
+14.elisp:13:4: In call to treesit-font-lock-rules: Unescaped literal `+' (pos 0)
+  "+f+"
+   ^
+14.elisp:13:4: In call to treesit-font-lock-rules: Unescaped literal `+' (pos 0)
+  "+g+"
+   ^
+14.elisp:29:4: In call to treesit-range-rules: Unescaped literal `+' (pos 0)
+  "+o+"
+   ^
+14.elisp:29:4: In call to treesit-range-rules: Unescaped literal `+' (pos 0)
+  "+p+"
+   ^
+14.elisp:33:23: In call to treesit-query-expand: Unescaped literal `+' (pos 0)
+  "+r+"
+   ^
+14.elisp:36:2: In call to treesit-query-compile: Unescaped literal `+' (pos 0)
+  "+t+"
+   ^
+14.elisp:39:29: In call to treesit-node-top-level: Unescaped literal `+' (pos 0)
+  "+u+"
+   ^
+14.elisp:40:28: In call to treesit-query-capture: Unescaped literal `+' (pos 0)
+  "+v+"
+   ^
+14.elisp:41:26: In call to treesit-query-range: Unescaped literal `+' (pos 0)
+  "+w+"
+   ^
+14.elisp:42:27: In call to treesit-query-string: Unescaped literal `+' (pos 0)
+  "+x+"
+   ^

--- a/test/2.elisp
+++ b/test/2.elisp
@@ -32,7 +32,11 @@
   (directory-files-recursively s "+3")
   (delete-matching-lines "+4")
   (delete-non-matching-lines "+5")
-  (count-matches "+6"))
+  (count-matches "+6")
+  (treesit-induce-sparse-tree n "+7")
+  (treesit-search-forward n "+8")
+  (treesit-search-forward-goto n "+9")
+  (treesit-search-subtree n "+10"))
 
 ;; Test argument names as means of detecting regexps.
 (defun f2 (x1 my-regexp x2 my-regex x3 my-re x4 my-pattern x5 re)

--- a/test/2.expected
+++ b/test/2.expected
@@ -97,69 +97,81 @@
 2.elisp:35:19: In call to count-matches: Unescaped literal `+' (pos 0)
   "+6"
    ^
-2.elisp:48:17: In call to f2: Duplicated `B' inside character alternative (pos 2)
+2.elisp:36:34: In call to treesit-induce-sparse-tree: Unescaped literal `+' (pos 0)
+  "+7"
+   ^
+2.elisp:37:30: In call to treesit-search-forward: Unescaped literal `+' (pos 0)
+  "+8"
+   ^
+2.elisp:38:35: In call to treesit-search-forward-goto: Unescaped literal `+' (pos 0)
+  "+9"
+   ^
+2.elisp:39:30: In call to treesit-search-subtree: Unescaped literal `+' (pos 0)
+  "+10"
+   ^
+2.elisp:52:17: In call to f2: Duplicated `B' inside character alternative (pos 2)
   "[BB]"
    ..^
-2.elisp:48:31: In call to f2: Duplicated `D' inside character alternative (pos 2)
+2.elisp:52:31: In call to f2: Duplicated `D' inside character alternative (pos 2)
   "[DD]"
    ..^
-2.elisp:48:45: In call to f2: Duplicated `F' inside character alternative (pos 2)
+2.elisp:52:45: In call to f2: Duplicated `F' inside character alternative (pos 2)
   "[FF]"
    ..^
-2.elisp:48:59: In call to f2: Duplicated `H' inside character alternative (pos 2)
+2.elisp:52:59: In call to f2: Duplicated `H' inside character alternative (pos 2)
   "[HH]"
    ..^
-2.elisp:48:73: In call to f2: Duplicated `J' inside character alternative (pos 2)
+2.elisp:52:73: In call to f2: Duplicated `J' inside character alternative (pos 2)
   "[JJ]"
    ..^
-2.elisp:49:17: In call to s2: Duplicated `B' inside character alternative (pos 2)
+2.elisp:53:17: In call to s2: Duplicated `B' inside character alternative (pos 2)
   "[BB]"
    ..^
-2.elisp:49:31: In call to s2: Duplicated `D' inside character alternative (pos 2)
+2.elisp:53:31: In call to s2: Duplicated `D' inside character alternative (pos 2)
   "[DD]"
    ..^
-2.elisp:49:45: In call to s2: Duplicated `F' inside character alternative (pos 2)
+2.elisp:53:45: In call to s2: Duplicated `F' inside character alternative (pos 2)
   "[FF]"
    ..^
-2.elisp:49:59: In call to s2: Duplicated `H' inside character alternative (pos 2)
+2.elisp:53:59: In call to s2: Duplicated `H' inside character alternative (pos 2)
   "[HH]"
    ..^
-2.elisp:49:73: In call to s2: Duplicated `J' inside character alternative (pos 2)
+2.elisp:53:73: In call to s2: Duplicated `J' inside character alternative (pos 2)
   "[JJ]"
    ..^
-2.elisp:50:17: In call to m2: Duplicated `B' inside character alternative (pos 2)
+2.elisp:54:17: In call to m2: Duplicated `B' inside character alternative (pos 2)
   "[BB]"
    ..^
-2.elisp:50:31: In call to m2: Duplicated `D' inside character alternative (pos 2)
+2.elisp:54:31: In call to m2: Duplicated `D' inside character alternative (pos 2)
   "[DD]"
    ..^
-2.elisp:50:45: In call to m2: Duplicated `F' inside character alternative (pos 2)
+2.elisp:54:45: In call to m2: Duplicated `F' inside character alternative (pos 2)
   "[FF]"
    ..^
-2.elisp:50:59: In call to m2: Duplicated `H' inside character alternative (pos 2)
+2.elisp:54:59: In call to m2: Duplicated `H' inside character alternative (pos 2)
   "[HH]"
    ..^
-2.elisp:50:73: In call to m2: Duplicated `J' inside character alternative (pos 2)
+2.elisp:54:73: In call to m2: Duplicated `J' inside character alternative (pos 2)
   "[JJ]"
    ..^
-2.elisp:58:17: In call to f5: Duplicated `b' inside character alternative (pos 2)
+2.elisp:62:17: In call to f5: Duplicated `b' inside character alternative (pos 2)
   "[bb]"
    ..^
-2.elisp:58:24: In call to f5: Duplicated `c' inside character alternative (pos 2)
+2.elisp:62:24: In call to f5: Duplicated `c' inside character alternative (pos 2)
   "[cc]"
    ..^
-2.elisp:58:31: In call to f5: Duplicated `d' inside character alternative (pos 2)
+2.elisp:62:31: In call to f5: Duplicated `d' inside character alternative (pos 2)
   "[dd]"
    ..^
-2.elisp:61:26: In :regexp parameter: Duplicated `1' inside character alternative (pos 2)
+2.elisp:65:26: In :regexp parameter: Duplicated `1' inside character alternative (pos 2)
   "[11]"
    ..^
-2.elisp:62:20: In :regex parameter: Duplicated `2' inside character alternative (pos 2)
+2.elisp:66:20: In :regex parameter: Duplicated `2' inside character alternative (pos 2)
   "[22]"
    ..^
-2.elisp:65:31: In call to sort-regexp-fields: Unescaped literal `$' (pos 3)
+2.elisp:69:31: In call to sort-regexp-fields: Unescaped literal `$' (pos 3)
   "^.*$x"
    ...^
-2.elisp:66:35: In call to sort-regexp-fields: Escaped non-special character `%' (pos 0)
+2.elisp:70:35: In call to sort-regexp-fields: Escaped non-special character `%' (pos 0)
   "\\%"
    ^

--- a/test/9.elisp
+++ b/test/9.elisp
@@ -17,12 +17,28 @@
         (page-delimiter "[jj]"))
     (let* ((comment-start-skip "[kk]")
            (comment-end-skip "[ll]"))
-      (asdf))))
+      (asdf)))
+
+  (setq treesit-sentence-type-regexp "+0")
+  (setq treesit-sexp-type-regexp "+1"))
+
+(defvar bad-imenu
+  '(("*less*" "" 0)
+    (nil "+b+" 0)))
+
+(defvar bad-treesit-imenu
+  '((nil "node" nil nil)
+    ("+++" "+c+" nil nil)))
 
 (defun test-9-ge ()
   (setq-local imenu-generic-expression
               '((nil "oh" 0)
-                ("*more*" "+a+" 0))))
+                ("*more*" "+a+" 0)))
+  (setq imenu-generic-expression bad-imenu)
+  (setq-local treesit-simple-imenu-settings bad-treesit-imenu)
+  (set (make-local-variable 'treesit-simple-imenu-settings)
+       '((nil "type" nil nil)
+         ("+more+" "+d+" nil nil))))
 
 (defun test-9-fl-kw ()
   (setq-local font-lock-keywords '(("[mm]" . tag)))
@@ -40,3 +56,15 @@
         '((my-fl-keyw-1
            my-font-lock-keywords-2)
           moo mooo)))
+
+(defun test-9-ts-indent ()
+  (setq treesit-simple-indent-rules
+        '((a ((match "+e+" "+f+" "+g+") a 0)
+             ((n-p-gp "+h+" "+i+" "+j+") a 0))
+          (b ((parent-is "+k+") b 0)
+             ((node-is "+l+") b 0)
+             ((field-is "+m+") b 0)))))
+
+(defun test-9-ts-defun ()
+  (setq treesit-defun-type-regexp "+n+")
+  (setq treesit-defun-type-regexp (cons "+o+" #'ignore)))

--- a/test/9.expected
+++ b/test/9.expected
@@ -34,21 +34,69 @@
 9.elisp:19:33: In comment-end-skip: Duplicated `l' inside character alternative (pos 2)
   "[ll]"
    ..^
-9.elisp:25:28: In imenu-generic-expression: Unescaped literal `+' (pos 0)
+9.elisp:22:39: In treesit-sentence-type-regexp: Unescaped literal `+' (pos 0)
+  "+0"
+   ^
+9.elisp:23:35: In treesit-sexp-type-regexp: Unescaped literal `+' (pos 0)
+  "+1"
+   ^
+9.elisp:36:28: In imenu-generic-expression: Unescaped literal `+' (pos 0)
   "+a+"
    ^
-9.elisp:28:40: In font-lock-keywords (tag): Duplicated `m' inside character alternative (pos 2)
+9.elisp:37:34: In imenu-generic-expression: Unescaped literal `+' (pos 0)
+  "+b+"
+   ^
+9.elisp:38:45: In treesit-simple-imenu-settings: Unescaped literal `+' (pos 0)
+  "+c+"
+   ^
+9.elisp:41:21: In treesit-simple-imenu-settings: Unescaped literal `+' (pos 0)
+  "+d+"
+   ^
+9.elisp:44:40: In font-lock-keywords (tag): Duplicated `m' inside character alternative (pos 2)
   "[mm]"
    ..^
-9.elisp:29:34: In font-lock-keywords (tag): Duplicated `n' inside character alternative (pos 2)
+9.elisp:45:34: In font-lock-keywords (tag): Duplicated `n' inside character alternative (pos 2)
   "[nn]"
    ..^
-9.elisp:30:56: In font-lock-keywords (tag): Duplicated `o' inside character alternative (pos 2)
+9.elisp:46:56: In font-lock-keywords (tag): Duplicated `o' inside character alternative (pos 2)
   "[oo]"
    ..^
-9.elisp:36:9: In my-font-lock-keywords-2 (beta): Duplicated `q' inside character alternative (pos 2)
+9.elisp:52:9: In my-font-lock-keywords-2 (beta): Duplicated `q' inside character alternative (pos 2)
   "[qq]"
    ..^
-9.elisp:40:9: In font-lock-defaults (alpha): Duplicated `p' inside character alternative (pos 2)
+9.elisp:56:9: In font-lock-defaults (alpha): Duplicated `p' inside character alternative (pos 2)
   "[pp]"
    ..^
+9.elisp:62:23: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+e+"
+   ^
+9.elisp:62:29: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+f+"
+   ^
+9.elisp:62:35: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+g+"
+   ^
+9.elisp:63:24: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+h+"
+   ^
+9.elisp:63:30: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+i+"
+   ^
+9.elisp:63:36: In treesit-simple-indent-rules (a): Unescaped literal `+' (pos 0)
+  "+j+"
+   ^
+9.elisp:64:27: In treesit-simple-indent-rules (b): Unescaped literal `+' (pos 0)
+  "+k+"
+   ^
+9.elisp:65:25: In treesit-simple-indent-rules (b): Unescaped literal `+' (pos 0)
+  "+l+"
+   ^
+9.elisp:66:26: In treesit-simple-indent-rules (b): Unescaped literal `+' (pos 0)
+  "+m+"
+   ^
+9.elisp:69:36: In treesit-defun-type-regexp: Unescaped literal `+' (pos 0)
+  "+n+"
+   ^
+9.elisp:70:35: In treesit-defun-type-regexp: Unescaped literal `+' (pos 0)
+  "+o+"
+   ^


### PR DESCRIPTION
This is an initial attempt to check the following Emacs 29 additions:
- `treesit-defun-type-regexp`
- `treesit-font-lock-rules`
- `treesit-sentence-type-regexp`
- `treesit-sexp-type-regexp`
- `treesit-simple-imenu-settings`
- `treesit-simple-indent-rules`

Marking the PR as draft because testing is incomplete.
I should be able to finish up with testing this week.

In the meantime I was hoping to get feedback on whether:
- these additions are welcome
- the coding style is acceptable
- I'm on the right track in general

and suggestions for improvements.

BTW, these checks have already been run against `emacs-29`:
the log is attached in PR mattiase/xr#6.

Thanks!